### PR TITLE
feat: upgrade to 4.2 compatibility

### DIFF
--- a/develop/Dockerfile
+++ b/develop/Dockerfile
@@ -6,6 +6,6 @@ RUN mkdir -p /source
 COPY .. /source
 
 # Install the plugin in netbox
-RUN /opt/netbox/venv/bin/pip install --editable /source
+RUN /usr/local/bin/uv pip install --editable /source || /opt/netbox/venv/bin/pip install  --no-warn-script-location /source
 
 WORKDIR /opt/netbox/netbox/

--- a/netbox_prometheus_sd/api/utils.py
+++ b/netbox_prometheus_sd/api/utils.py
@@ -1,5 +1,13 @@
 import json
 from netaddr import IPNetwork
+from packaging import version
+from netbox.settings import VERSION
+
+VERSION = VERSION.split("-")[0]
+
+NETBOX_RELEASE_CURRENT = version.parse(VERSION)
+NETBOX_RELEASE_40 = version.parse("4.0.11")
+NETBOX_RELEASE_41 = version.parse("4.1.11")
 
 
 class LabelDict(dict):
@@ -58,11 +66,21 @@ def extract_cluster(obj, labels: LabelDict):
             labels["cluster_group"] = obj.cluster.group.name
         if obj.cluster.type:
             labels["cluster_type"] = obj.cluster.type.name
-        if obj.cluster.site:
-            labels["site"] = obj.cluster.site.name
-            labels["site_slug"] = obj.cluster.site.slug
+        try: # Netbox >4.2
+            if obj.cluster.scope:
+                labels["scope"] = obj.cluster.scope.name
+                labels["scope_slug"] = obj.cluster.scope.slug
+        except AttributeError: # Netbox <4.2
+            if obj.cluster.site:
+                labels["site"] = obj.cluster.site.name
+                labels["site_slug"] = obj.cluster.site.slug
 
-    # Has precedence over cluster site
+    # Has precedence over cluster scope
+    if hasattr(obj, "scope") and obj.scope is not None:
+        labels["scope"] = obj.scope.name
+        labels["scope_slug"] = obj.scope.slug
+
+    # Still Return site labels for Devices
     if hasattr(obj, "site") and obj.site is not None:
         labels["site"] = obj.site.name
         labels["site_slug"] = obj.site.slug

--- a/netbox_prometheus_sd/api/views.py
+++ b/netbox_prometheus_sd/api/views.py
@@ -24,6 +24,8 @@ except ImportError:
             CustomFieldModelViewSet as NetboxPrometheusSDModelViewSet,
         )
 
+from .utils import NETBOX_RELEASE_CURRENT, NETBOX_RELEASE_41
+
 # Filtersets have been renamed, we support both
 # https://github.com/netbox-community/netbox/commit/1024782b9e0abb48f6da65f8248741227d53dbed#diff-d9224204dab475bbe888868c02235b8ef10f07c9201c45c90804d395dc161c40
 try:
@@ -58,8 +60,12 @@ class ServiceViewSet(NetboxPrometheusSDModelViewSet):
 
 
 class VirtualMachineViewSet(NetboxPrometheusSDModelViewSet):
+    if NETBOX_RELEASE_CURRENT > NETBOX_RELEASE_41:
+        cluster_scope = "cluster__scope"
+    else:
+        cluster_scope = "cluster__site"
     queryset = VirtualMachine.objects.prefetch_related(
-        "cluster__site",
+        cluster_scope,
         "role",
         "tenant",
         "platform",

--- a/netbox_prometheus_sd/tests/test_serializers.py
+++ b/netbox_prometheus_sd/tests/test_serializers.py
@@ -1,5 +1,4 @@
 from django.test import TestCase
-
 from ..api.serializers import (
     PrometheusDeviceSerializer,
     PrometheusIPAddressSerializer,
@@ -8,6 +7,7 @@ from ..api.serializers import (
 )
 from . import utils
 
+from ..api.utils import NETBOX_RELEASE_CURRENT, NETBOX_RELEASE_41
 
 class PrometheusVirtualMachineSerializerTests(TestCase):
     def test_vm_minimal_to_target(self):
@@ -99,6 +99,28 @@ class PrometheusVirtualMachineSerializerTests(TestCase):
                     {"__meta_netbox_site_slug": "campus-a"}, data["labels"]
                 )
             )
+            if NETBOX_RELEASE_CURRENT > NETBOX_RELEASE_41:
+                self.assertTrue(
+                    utils.dictContainsSubset(
+                        {"__meta_netbox_scope": "Campus A"}, data["labels"]
+                    )
+                )
+                self.assertTrue(
+                    utils.dictContainsSubset(
+                        {"__meta_netbox_scope_slug": "campus-a"}, data["labels"]
+                    )
+                )
+            else:
+                self.assertTrue(
+                    utils.dictContainsSubset(
+                        {"__meta_netbox_site": "Campus A"}, data["labels"]
+                    )
+                )
+                self.assertTrue(
+                    utils.dictContainsSubset(
+                        {"__meta_netbox_site_slug": "campus-a"}, data["labels"]
+                    )
+                )
             self.assertTrue(
                 utils.dictContainsSubset({"__meta_netbox_role": "VM"}, data["labels"])
             )
@@ -517,6 +539,28 @@ class PrometheusServiceSerializerTests(TestCase):
                     {"__meta_netbox_site_slug": "campus-a"}, data["labels"]
                 )
             )
+            if NETBOX_RELEASE_CURRENT > NETBOX_RELEASE_41:
+                self.assertTrue(
+                    utils.dictContainsSubset(
+                        {"__meta_netbox_scope": "Campus A"}, data["labels"]
+                    )
+                )
+                self.assertTrue(
+                    utils.dictContainsSubset(
+                        {"__meta_netbox_scope_slug": "campus-a"}, data["labels"]
+                    )
+                )
+            else:
+                self.assertTrue(
+                    utils.dictContainsSubset(
+                        {"__meta_netbox_site": "Campus A"}, data["labels"]
+                    )
+                )
+                self.assertTrue(
+                    utils.dictContainsSubset(
+                        {"__meta_netbox_site_slug": "campus-a"}, data["labels"]
+                    )
+                )
             self.assertTrue(
                 utils.dictContainsSubset(
                     {"__meta_netbox_primary_ip": "2001:db8:1701::2"}, data["labels"]

--- a/netbox_prometheus_sd/tests/utils.py
+++ b/netbox_prometheus_sd/tests/utils.py
@@ -1,3 +1,6 @@
+from django.contrib.contenttypes.models import ContentType
+from django.core.exceptions import FieldError
+
 from dcim.models.devices import DeviceType, Manufacturer
 from dcim.models.sites import Site, Location
 from dcim.models import Device, DeviceRole, Platform, Rack
@@ -20,12 +23,22 @@ def dictContainsSubset(subset, fullset):
 
 
 def build_cluster():
-    return Cluster.objects.get_or_create(
-        name="DC1",
-        group=ClusterGroup.objects.get_or_create(name="VMware")[0],
-        type=ClusterType.objects.get_or_create(name="On Prem")[0],
-        site=Site.objects.get_or_create(name="Campus A", slug="campus-a")[0],
-    )[0]
+    try: # NetBox 4.2+
+        scope_type = ContentType.objects.get_for_model(Site)
+        return Cluster.objects.get_or_create(
+            name="DC1",
+            group=ClusterGroup.objects.get_or_create(name="VMware")[0],
+            type=ClusterType.objects.get_or_create(name="On Prem")[0],
+            scope_type=scope_type,
+            scope_id=Site.objects.get_or_create(name="Campus A", slug="campus-a")[0].id,
+        )[0]
+    except FieldError: # NetBox <4.2
+        return Cluster.objects.get_or_create(
+            name="DC1",
+            group=ClusterGroup.objects.get_or_create(name="VMware")[0],
+            type=ClusterType.objects.get_or_create(name="On Prem")[0],
+            site=Site.objects.get_or_create(name="Campus A", slug="campus-a")[0],
+        )[0]
 
 
 def build_location():


### PR DESCRIPTION
Fix: Add tests for netbox 4.2 migrat site => scope for virtual machine clusters as requested in PR #215 (#216)

* fix: netbox 4.2 migrat site => scope for virtual machine clusters

* test: :white_check_mark: Fix tests and add missing ones for new virtual machine cluster structure

Netbox now uses generic relations (scope) instead of a direct site relation.  A fix was created in PR #215 but is missing tests.  This commit includes the missing tests.

Closes #212

* fix: :bug: Fix pip in Dockerfile

As per the Netbox Docker documentation, pip should be called from /user/local/bin/uv.  Right now. the Docker build fails due to the wrong pip being used.

* fix: make plugin backwards compatible with pre Netbox 4.2

Add Netbox version checks to decide whether the scope or site fields should be used.  Make Docker work on all recent Netbox versions

---------

## Describe your changes

## Issue ticket number and link

## Checklist before requesting a review

- [ ] I have performed a self-review of my code
- [ ] If it is a core feature, I have added thorough tests.
